### PR TITLE
Fixed: str concatenation, socket import, filename stating with null b…

### DIFF
--- a/pyexfil/ICMP/icmp_exfiltration.py
+++ b/pyexfil/ICMP/icmp_exfiltration.py
@@ -186,7 +186,7 @@ def init_listener(ip_addr, saving_location="."):
 			else:
 				log_fh.write("Got termination packet for %s\n" % man_array[0])
 				comp_crc = zlib.crc32(current_file)
-				if True:#str(comp_crc) == checksum:
+				if str(comp_crc) == checksum:
 					# CRC validated
 					log_fh.write("CRC validation is green for " + str(comp_crc) + " with file name: " + filename + "\n")
 					current_file = base64.b64decode(current_file)


### PR DESCRIPTION
…yte, elif with never met condition, etc.

Collaboration with @matthieuxyz

Fixed some problems in ICMP:

- Fixed concatenation between str and int
- Fixed socket import mismatch between "import socket" and "import * from socket"
- Temporary workaround: filename always starting with a null byte. We aren't sure why...
- Temporary workaround: Removed some elseif because the condition is never met.